### PR TITLE
Fixed cr.yandex error bug

### DIFF
--- a/.github/workflows/backend-build.yaml
+++ b/.github/workflows/backend-build.yaml
@@ -51,6 +51,7 @@ jobs:
     - name: Build and push the Docker image
       uses: docker/build-push-action@v4
       with:
+        provenance: false
         cache-from: type=registry,ref=${{ vars.DOCKERHUB_BACKEND_IMAGE }}
         cache-to: type=registry,ref=${{ vars.DOCKERHUB_BACKEND_IMAGE }}
         context: "effectiveOfficeBackend" # FIXME: hardcoded context


### PR DESCRIPTION
cr.yandex is incompatible with buildx > 0.9.1. The solution is to downgrade the buildx version or disable the provenance arguments.
ref: https://github.com/docker/buildx/issues/1513