### PR TITLE
Animated visibility for DataTimeView when scrolling slots

### DIFF
--- a/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/mainScreen/MainScreenView.kt
+++ b/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/mainScreen/MainScreenView.kt
@@ -2,6 +2,7 @@ package band.effective.office.tablet.ui.mainScreen.mainScreen
 
 import android.annotation.SuppressLint
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -16,16 +17,22 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 import band.effective.office.tablet.domain.model.RoomInfo
 import band.effective.office.tablet.features.roomInfo.MainRes
@@ -38,7 +45,7 @@ import band.effective.office.tablet.ui.theme.LocalCustomColorsPalette
 import band.effective.office.tablet.ui.theme.textButton
 import java.util.Calendar
 
-@SuppressLint("NewApi", "StateFlowValueCalledInComposition")
+@SuppressLint("NewApi", "StateFlowValueCalledInComposition", "UnrememberedMutableState")
 @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
 @Composable
 fun MainScreenView(
@@ -57,6 +64,12 @@ fun MainScreenView(
     selectDate: Calendar,
     onResetDate: () -> Unit
 ) {
+
+    val listState = rememberLazyListState()
+    val fabVisibility by derivedStateOf {
+        listState.firstVisibleItemScrollOffset == 0 && listState.firstVisibleItemIndex == 0
+    }
+
     Box(modifier = Modifier.fillMaxSize().background(color = MaterialTheme.colors.background)) {
         /*NOTE(Maksim Mishenko):
         * infoViewWidth is part of the width occupied by roomInfoView
@@ -76,9 +89,10 @@ fun MainScreenView(
                         selectDate = selectDate,
                         timeToNextEvent = timeToNextEvent,
                         isError = isDisconnect,
-                        onResetDate = onResetDate
+                        onResetDate = onResetDate,
+                        visibleDataTimeView = fabVisibility
                     )
-                    SlotList(slotComponent)
+                    SlotList(slotComponent, listState)
                 }
                 Box(modifier = Modifier.padding(horizontal = 30.dp)) {
                     Disconnect(visible = isDisconnect)

--- a/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/mainScreen/MainScreenView.kt
+++ b/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/mainScreen/MainScreenView.kt
@@ -114,7 +114,7 @@ fun MainScreenView(
                     items(slotState.slots) {
                         Box(modifier = Modifier
                             .fillMaxSize()
-                            .padding(start = 30.dp, end = 30.dp)) {
+                            .padding(horizontal = 30.dp)) {
                             SlotView(
                                 slotUi = it,
                                 onClick = { slotComponent.sendIntent(

--- a/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/mainScreen/MainScreenView.kt
+++ b/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/mainScreen/MainScreenView.kt
@@ -77,9 +77,14 @@ fun MainScreenView(
         * where infoViewFrame, mainScreenFrame is frames from figma and all width I get from figma*/
         val infoViewWidth = 627f / 1133f
         Row(modifier = Modifier.fillMaxSize()) {
-            Box(modifier = Modifier.fillMaxHeight().fillMaxWidth(infoViewWidth)) {
+            Box(modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(infoViewWidth)) {
                 LazyColumn(
-                    modifier = Modifier.fillMaxHeight().fillMaxWidth().padding(bottom = 30.dp)) {
+                    modifier = Modifier
+                        .fillMaxHeight()
+                        .fillMaxWidth().
+                        padding(bottom = 30.dp)) {
                     item {
                         DateTimeView(
                             modifier = Modifier.padding(
@@ -98,7 +103,8 @@ fun MainScreenView(
                     }
                     stickyHeader{
                             RoomInfoComponent(
-                                modifier = Modifier.background(color = MaterialTheme.colors.background),
+                                modifier = Modifier
+                                    .background(color = MaterialTheme.colors.background),
                                 room = roomList[indexSelectRoom],
                                 onOpenFreeRoomModalRequest = { onCancelEventRequest() },
                                 timeToNextEvent = timeToNextEvent,
@@ -106,7 +112,9 @@ fun MainScreenView(
                             )
                     }
                     items(slotState.slots) {
-                        Box(modifier = Modifier.fillMaxSize().padding(start = 30.dp, end = 30.dp)) {
+                        Box(modifier = Modifier
+                            .fillMaxSize()
+                            .padding(start = 30.dp, end = 30.dp)) {
                             SlotView(
                                 slotUi = it,
                                 onClick = { slotComponent.sendIntent(

--- a/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/roomInfoComponents/RoomInfoView.kt
+++ b/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/roomInfoComponents/RoomInfoView.kt
@@ -2,6 +2,7 @@ package band.effective.office.tablet.ui.mainScreen.roomInfoComponents
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -16,7 +17,6 @@ import band.effective.office.tablet.ui.mainScreen.roomInfoComponents.uiComponent
 import java.util.Calendar
 import java.util.GregorianCalendar
 
-
 @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
 @Composable
 fun RoomInfoComponent(
@@ -29,24 +29,30 @@ fun RoomInfoComponent(
     selectDate: Calendar,
     timeToNextEvent: Int,
     isError: Boolean,
-    onResetDate: () -> Unit
+    onResetDate: () -> Unit,
+    visibleDataTimeView: Boolean
 ) {
     val paddings = 30.dp
     Column(modifier = modifier) {
-        DateTimeView(
-            modifier = Modifier.padding(
-                start = paddings,
-                top = 50.dp,
-                end = 20.dp,
-                bottom = 0.dp
-            ).height(70.dp),
-            selectDate = selectDate,
-            increment = onIncrementDate,
-            decrement = onDecrementDate,
-            onOpenDateTimePickerModal = onOpenDateTimePickerModalRequest,
-            currentDate = GregorianCalendar(),
-            back = onResetDate,
-        )
+        AnimatedVisibility(
+            visible = visibleDataTimeView,
+            modifier = Modifier
+        ){
+            DateTimeView(
+                modifier = Modifier.padding(
+                    start = paddings,
+                    top = 50.dp,
+                    end = 20.dp,
+                    bottom = 0.dp
+                ).height(70.dp),
+                selectDate = selectDate,
+                increment = onIncrementDate,
+                decrement = onDecrementDate,
+                onOpenDateTimePickerModal = onOpenDateTimePickerModalRequest,
+                currentDate = GregorianCalendar(),
+                back = onResetDate,
+            )
+        }
         when {
             room.isFree() -> {
                 FreeRoomInfoComponent(

--- a/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/roomInfoComponents/RoomInfoView.kt
+++ b/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/roomInfoComponents/RoomInfoView.kt
@@ -23,36 +23,11 @@ fun RoomInfoComponent(
     modifier: Modifier = Modifier,
     room: RoomInfo,
     onOpenFreeRoomModalRequest: () -> Unit,
-    onOpenDateTimePickerModalRequest: () -> Unit,
-    onIncrementDate: () -> Unit,
-    onDecrementDate: () -> Unit,
-    selectDate: Calendar,
     timeToNextEvent: Int,
     isError: Boolean,
-    onResetDate: () -> Unit,
-    visibleDataTimeView: Boolean
 ) {
     val paddings = 30.dp
     Column(modifier = modifier) {
-        AnimatedVisibility(
-            visible = visibleDataTimeView,
-            modifier = Modifier
-        ){
-            DateTimeView(
-                modifier = Modifier.padding(
-                    start = paddings,
-                    top = 50.dp,
-                    end = 20.dp,
-                    bottom = 0.dp
-                ).height(70.dp),
-                selectDate = selectDate,
-                increment = onIncrementDate,
-                decrement = onDecrementDate,
-                onOpenDateTimePickerModal = onOpenDateTimePickerModalRequest,
-                currentDate = GregorianCalendar(),
-                back = onResetDate,
-            )
-        }
         when {
             room.isFree() -> {
                 FreeRoomInfoComponent(

--- a/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/slotComponent/SlotView.kt
+++ b/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/slotComponent/SlotView.kt
@@ -20,7 +20,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material3.Text
@@ -45,17 +47,19 @@ import band.effective.office.tablet.ui.mainScreen.slotComponent.store.SlotStore
 import band.effective.office.tablet.ui.theme.LocalCustomColorsPalette
 import band.effective.office.tablet.ui.theme.h7
 import band.effective.office.tablet.ui.theme.subslotColor
+import org.koin.core.component.getScopeId
 import java.text.SimpleDateFormat
 import java.util.Calendar
 
 @RequiresApi(Build.VERSION_CODES.N)
 @Composable
-fun SlotList(component: SlotComponent) {
+fun SlotList(component: SlotComponent, listState: LazyListState) {
     val state by component.state.collectAsState()
     SlotList(
         slots = state.slots,
         onClick = { component.sendIntent(SlotStore.Intent.ClickOnSlot(this)) },
-        onCancel = { component.sendIntent(SlotStore.Intent.OnCancelDelete(it)) }
+        onCancel = { component.sendIntent(SlotStore.Intent.OnCancelDelete(it)) },
+        state = listState
     )
 }
 
@@ -63,14 +67,16 @@ fun SlotList(component: SlotComponent) {
 private fun SlotList(
     slots: List<SlotUi>,
     onClick: SlotUi.() -> Unit,
-    onCancel: (SlotUi.DeleteSlot) -> Unit
+    onCancel: (SlotUi.DeleteSlot) -> Unit,
+    state: LazyListState
 ) {
     LazyColumn(
-        Modifier.padding(start = 30.dp, top = 0.dp, end = 30.dp, bottom = 30.dp)
+        Modifier.padding(start = 30.dp, top = 0.dp, end = 30.dp, bottom = 30.dp),
+        state = state,
     ) {
-        items(items = slots) {
-            SlotView(slotUi = it, onClick = onClick, onCancel = onCancel)
-            Spacer(Modifier.height(20.dp))
+        itemsIndexed(items = slots) { id, slot ->
+            SlotView(slotUi = slot, onClick = onClick, onCancel = onCancel)
+            Spacer(Modifier.height(if (id != slots.lastIndex) 20.dp else 90.dp))
         }
     }
 }

--- a/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/slotComponent/SlotView.kt
+++ b/tabletApp/features/roomInfo/src/commonMain/kotlin/band/effective/office/tablet/ui/mainScreen/slotComponent/SlotView.kt
@@ -53,13 +53,12 @@ import java.util.Calendar
 
 @RequiresApi(Build.VERSION_CODES.N)
 @Composable
-fun SlotList(component: SlotComponent, listState: LazyListState) {
+fun SlotList(component: SlotComponent) {
     val state by component.state.collectAsState()
     SlotList(
         slots = state.slots,
         onClick = { component.sendIntent(SlotStore.Intent.ClickOnSlot(this)) },
         onCancel = { component.sendIntent(SlotStore.Intent.OnCancelDelete(it)) },
-        state = listState
     )
 }
 
@@ -68,21 +67,19 @@ private fun SlotList(
     slots: List<SlotUi>,
     onClick: SlotUi.() -> Unit,
     onCancel: (SlotUi.DeleteSlot) -> Unit,
-    state: LazyListState
 ) {
     LazyColumn(
         Modifier.padding(start = 30.dp, top = 0.dp, end = 30.dp, bottom = 30.dp),
-        state = state,
     ) {
         itemsIndexed(items = slots) { id, slot ->
             SlotView(slotUi = slot, onClick = onClick, onCancel = onCancel)
-            Spacer(Modifier.height(if (id != slots.lastIndex) 20.dp else 90.dp))
+            Spacer(Modifier.height(20.dp))
         }
     }
 }
 
 @Composable
-private fun SlotView(
+fun SlotView(
     slotUi: SlotUi,
     onClick: SlotUi.() -> Unit,
     onCancel: (SlotUi.DeleteSlot) -> Unit


### PR DESCRIPTION
Add animated visibility for DataTimeView when scrolling slots, 
Some problem: I neded add spacer 90.dp (not 20.dp) to the end of list of slots for to escape problem, that was described in notion task.