### PR TITLE
Fix tvApp build

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,6 @@ shadow = "7.1.2"
 gms = "20.4.0"
 
 [libraries]
-avif-coder = { module = "com.github.awxkee:avif-coder", version.ref = "avifCoderCoil" }
 avif-coder-coil = { module = "com.github.awxkee:avif-coder-coil", version.ref = "avifCoderCoil" }
 retrofit = {module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit-ver"}
 moshi = {module = "com.squareup.moshi:moshi", version.ref = "moshi-ver"}

--- a/tvApp/build.gradle.kts
+++ b/tvApp/build.gradle.kts
@@ -15,7 +15,7 @@ localProperties.load(FileInputStream(rootProject.file("local.properties")))
 
 android {
     namespace  = "band.effective.office.tv"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId  = "band.effective.office.tv"
@@ -106,7 +106,6 @@ dependencies {
     implementation(libs.coil.svg)
 
     //Avif decoder coil plugin
-    implementation(libs.avif.coder)
     implementation(libs.avif.coder.coil)
 
     //notion


### PR DESCRIPTION
[+] updated compileSDK version to cooperate with avif decoder version 
[+] removed unnecessary lib

P.S. Tv app does not build because of compileSDK cersion is `33`, so `avif decoder` demands `34`. I updated compileSDK to 34 in gradle and removed unnecessary lib