### PR TITLE
Backend: fix googleCalendarConverter for fast booking

### DIFF
--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/features/booking/converters/GoogleCalendarConverter.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/features/booking/converters/GoogleCalendarConverter.kt
@@ -164,7 +164,9 @@ class GoogleCalendarConverter(
             beginBooking = toLocalInstant(event.start),
             endBooking = toLocalInstant(event.end),
             recurrence = recurrence?.let { RecurrenceConverter.recurrenceToModel(it) },
-            isDeclinedByOwner = participantModels.none { model -> model.email == organizerEmail }
+            isDeclinedByOwner = organizerEmail?.let { email ->
+                participantModels.none { model -> model.email == email }
+            } ?: false
         )
         logger.trace("[toMeetingWorkspaceBooking] {}", booking.toString())
         return booking


### PR DESCRIPTION
Changed logic of flag "isDeclinedByOwner" in GoogleCalendarConverter, becouse if Booking hasn't an organizer, "isDeclinedByOwner" always be true (.none returns true) so tablet doesn't recieve bookings, that haven't an organizer.